### PR TITLE
Upgrade version to 2022.04.0-7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 # defaults file
 ---
-rstudio_package_manager_version: "2021.12.0-3"
+rstudio_package_manager_version: "2022.04.0-7"
 rstudio_package_manager_install: []
 
 rstudio_package_manager_enable_repositories: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,6 @@
 # meta file
 ---
 galaxy_info:
-  namespace: appsilon
   role_name: rstudio_package_manager
   author: shmileee
   company: Appsilon

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,7 +4,7 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: instance
+  - name: instance-rspm
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:

--- a/tasks/repositories.yml
+++ b/tasks/repositories.yml
@@ -33,7 +33,7 @@
 
     - name: repositories | import default SSH key
       ansible.builtin.shell: |
-        /opt/rstudio-pm/bin/rspm import --name=default --path=/var/lib/rstudio-pm/default-ssh-key || true
+        /opt/rstudio-pm/bin/rspm import ssh-key --name=default --path=/var/lib/rstudio-pm/default-ssh-key || true
       register: out
       changed_when: out.rc != 0
   tags:
@@ -53,7 +53,7 @@
 
 - name: repositories | create Git builders
   ansible.builtin.shell: |
-    /opt/rstudio-pm/bin/rspm create git-builder --source=internal-git-src --url={{ item.name }} --ssh-key=default --build-trigger={{ item.trigger }} || true
+    /opt/rstudio-pm/bin/rspm create git-builder --source=internal-git-src --url={{ item.name }} --credential=default --build-trigger={{ item.trigger }} || true
   loop: "{{ rstudio_package_manager_git_repositories }}"
   when:
     - rstudio_package_manager_git_repositories is defined


### PR DESCRIPTION
## Changes description

This PR:
- upgrades default RSPM version to 2022.04.0-7, which has some breaking changes
- adds support for these changes

For more information regarding the changes, see official [release notes](https://docs.rstudio.com/rspm/news/#rstudio-package-manager-2022040) for RStudio Package manager.