### PR TITLE
fix: use different capability for Ubuntu >= 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
         include:
           - distro: ubuntu2004
             ansible-version: '>=2.11.5'
+          - distro: ubuntu2204
+            ansible-version: '>=2.11.5'
           - distro: rockylinux8
             ansible-version: '>=2.11.5'
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -51,7 +51,7 @@
     path: /opt/rstudio-pm/bin/rstudio-pm
     capability: cap_net_bind_service+ep
     state: present
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family == "Debian" and not (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('22.04', '>='))
   tags:
     - rstudio-package-manager-set-caps
 
@@ -60,7 +60,7 @@
     path: /opt/rstudio-pm/bin/rstudio-pm
     capability: cap_net_bind_service=ep
     state: present
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" or (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('22.04', '>='))
   tags:
     - rstudio-package-manager-set-caps
 


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #

## Description
*Clear and concise description of what changed and why.
If necessary, include screenshots and/or a step-by-step guide on how to test the changes.*

Fix idempotence issue which occurs while running `molecule test` for Ubuntu 22.04

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
