### PR TITLE
fix(ci): install Python deps from requirements.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies
-        run: pip install ansible-lint[community,yamllint] ansible-core
+        run: pip install -r requirements.txt
 
       - name: Install dependencies from requirements.yaml
         run: |
@@ -48,11 +48,8 @@ jobs:
       matrix:
         include:
           - distro: ubuntu2004
-            ansible-version: '>=2.11.5'
           - distro: ubuntu2204
-            ansible-version: '>=2.11.5'
           - distro: rockylinux8
-            ansible-version: '>=2.11.5'
 
     steps:
       - name: Check out the codebase
@@ -66,7 +63,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies
-        run: pip install 'ansible${{ matrix.ansible-version }}' molecule molecule-plugins[docker] docker
+        run: pip install -r requirements.txt
 
       - name: Run Molecule tests
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 ansible==9.3.0
-ansible-compat==4.1.11
+ansible-compat==24.6.1
 ansible-core==2.16.4
+ansible-lint==24.6.1
 attrs==23.2.0
+black==24.4.2
 bracex==2.4
 certifi==2024.2.2
 cffi==1.16.0
@@ -12,7 +14,9 @@ cryptography==42.0.5
 distro==1.9.0
 docker==7.0.0
 enrich==1.2.7
+filelock==3.15.4
 idna==3.6
+importlib_metadata==8.0.0
 Jinja2==3.1.3
 jsonschema==4.21.1
 jsonschema-specifications==2023.12.1
@@ -21,7 +25,10 @@ MarkupSafe==2.1.5
 mdurl==0.1.2
 molecule==24.2.0
 molecule-plugins==23.5.3
+mypy-extensions==1.0.0
 packaging==23.2
+pathspec==0.12.1
+platformdirs==4.2.2
 pluggy==1.4.0
 pycparser==2.21
 Pygments==2.17.2
@@ -31,7 +38,11 @@ requests==2.31.0
 resolvelib==1.0.1
 rich==13.7.1
 rpds-py==0.18.0
+ruamel.yaml==0.18.6
+ruamel.yaml.clib==0.2.8
 selinux==0.3.0
 subprocess-tee==0.4.1
 urllib3==2.2.1
 wcmatch==8.5.1
+yamllint==1.35.1
+zipp==3.19.2


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #

## Description

- The package versions should match what we have in requirements.txt file
- There's an issue when running molecule with Rocky Linux 8 ([_ansible-core >= 2.17 only supports Python 3.7+ for target executions_](https://github.com/ansible/ansible/issues/82068#issuecomment-2135279350); Rocky Linux uses 3.6 by default)

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
